### PR TITLE
Issue90 bugfix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId 'com.dawsonsoftware.meadmate'
         minSdkVersion 26
         targetSdk 31
-        versionCode 14
-        versionName '1.14'
+        versionCode 15
+        versionName '1.15'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,5 +15,10 @@
             </intent-filter>
         </activity>
     </application>
-
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.INSERT" />
+            <data android:mimeType="vnd.android.cursor.dir/event" />
+        </intent>
+    </queries>
 </manifest>

--- a/app/src/main/assets/index-a.html
+++ b/app/src/main/assets/index-a.html
@@ -612,18 +612,12 @@
 	</div>
 	<div role="main" class="ui-content">
 		<h2 class="content-title">About</h2>
-		<h3>Mead Mate Release 13</h3>
-		<p>The long awaited Dark Mode is here! I was experimenting with React Native and native Android UIs to modernize the app, but a user reached out to me recently about dark mode. For them, dark mode is not a preference, but a necessity. This is for you, Michael. Enjoy!</p>
+		<h3>Mead Mate Release 15</h3>
+		<p>Just a quick bug fix. I updated the API level of the app, but I didn't notice that extra declarations were needed for Mead Mate to insert a calendar event.</p>
+		<p>It's working on my Pixel 7a and in the Pixel 3a emulator. Please let me know if isn't working for you.</p>
 		<p><strong>What's New</strong></p>
 		<ul>
-			<li>Reformatted the Preferences page</li>
-			<li>Added support for a Dark Mode theme</li>
-			<li>Added new 'themeable' datepicker</li>
-			<li>Minor updates to ABV Calculator view</li>
-			<li>Update jQuery version</li>
-			<li>Fixed minor issues with form validators</li>
-			<li>Customized Reading and Event forms to go back to their lists</li>
-			<li>Set 'today' as default date for new meads, events, and readings</li>
+			<li>Updated the app manifest to fix issue with setting reminders.</li>
 		</ul>
 
 		<h3>Open Source Project Information</h3>

--- a/app/src/main/assets/index-b.html
+++ b/app/src/main/assets/index-b.html
@@ -612,18 +612,12 @@
 	</div>
 	<div role="main" class="ui-content">
 		<h2 class="content-title">About</h2>
-		<h3>Mead Mate Release 13</h3>
-		<p>The long awaited Dark Mode is here! I was experimenting with React Native and native Android UIs to modernize the app, but a user reached out to me recently about dark mode. For them, dark mode is not a preference, but a necessity. This is for you, Michael. Enjoy!</p>
+		<h3>Mead Mate Release 15</h3>
+		<p>Just a quick bug fix. I updated the API level of the app, but I didn't notice that extra declarations were needed for Mead Mate to insert a calendar event.</p>
+		<p>It's working on my Pixel 7a and in the Pixel 3a emulator. Please let me know if isn't working for you.</p>
 		<p><strong>What's New</strong></p>
 		<ul>
-			<li>Reformatted the Preferences page</li>
-			<li>Added support for a Dark Mode theme</li>
-			<li>Added new 'themeable' datepicker</li>
-			<li>Minor updates to ABV Calculator view</li>
-			<li>Update jQuery version</li>
-			<li>Fixed minor issues with form validators</li>
-			<li>Customized Reading and Event forms to go back to their lists</li>
-			<li>Set 'today' as default date for new meads, events, and readings</li>
+			<li>Updated the app manifest to fix issue with setting reminders.</li>
 		</ul>
 
 		<h3>Open Source Project Information</h3>


### PR DESCRIPTION
Updated manifest to allow Add Reminder feature to work. The root cause was due to updating the API version and the increased privacy features Android is implementing. An update to the Android app manifest was necessary.