### PR TITLE
Changing Dark Mode "Preferences" Menu item to what it shows in Honey Color Theme for consistency 

### DIFF
--- a/app/src/main/assets/index-b.html
+++ b/app/src/main/assets/index-b.html
@@ -60,7 +60,7 @@
 	<div data-role="panel" id="main-menu-batches" data-position="right" data-display="overlay">
 		<ul data-role="listview">
 			<li><a href="#mead-types" class="ui-btn ui-icon-info ui-btn-icon-left">Types of Mead</a></li>
-			<li><a href="#preferences" class="ui-btn ui-icon-gear ui-btn-icon-left">Preferences</a></li>
+			<li><a href="#preferences" class="ui-btn ui-icon-gear ui-btn-icon-left">Settings &amp; Tools</a></li>
 			<li><a href="#privacy-policy" class="ui-btn ui-icon-eye ui-btn-icon-left">Privacy Policy</a></li>
 			<li><a href="#about" class="ui-btn ui-icon-info ui-btn-icon-left">About</a></li>
 			<li><a href="#support" class="ui-btn ui-icon-comment ui-btn-icon-left">Support</a></li>


### PR DESCRIPTION
I noticed that when turning on Dark Mode that the menu item called "Settings & Tools" switched to being called "Preferences". 

Would you want to have both Honey theme and Dark theme both show "Settings & Tools" as the Settings menu item?